### PR TITLE
Add custom.sh and sub-scripts for handling basic-solr-config on Vagrant [DIT-59] [TRAC-47]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .vagrant
 downloads
-scripts/custom.sh
 package.box

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -4,7 +4,7 @@ echo "Running custom scripts"
 
 SHARED_DIR=$1
 
-if [ -f "SHARED_DIR/configs/variables" ]; then
+if [ -f "$SHARED_DIR/configs/variables" ]; then
 	. "$SHARED_DIR"/configs/variables
 fi
 

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Running custom scripts"
+
+source ./custom_scripts/update_basic_solr_config.sh

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -10,8 +10,8 @@ fi
 # run all shell scripts in scripts/custom_scripts/
 for SCRIPT in ${SHARED_DIR}/scripts/custom_scripts/*.sh
 do
-	if [ -f $SCRIPT ]; then
+	if [ -f "$SCRIPT" ]; then
 		echo "Running custom scripts"
-			source $SCRIPT
+			source "$SCRIPT"
 	fi
 done

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-echo "Running custom scripts"
-
 SHARED_DIR=$1
 
 if [ -f "$SHARED_DIR/configs/variables" ]; then
+	# shellcheck source=/dev/null
 	. "$SHARED_DIR"/configs/variables
 fi
 
-source "$SHARED_DIR"/scripts/custom_scripts/update_basic_solr_config.sh
+# run all shell scripts in scripts/custom_scripts/
+for SCRIPT in ${SHARED_DIR}/scripts/custom_scripts/*.sh
+do
+	if [ -f $SCRIPT ]; then
+		echo "Running custom scripts"
+			source $SCRIPT
+	fi
+done

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -2,4 +2,10 @@
 
 echo "Running custom scripts"
 
-source ./custom_scripts/update_basic_solr_config.sh
+SHARED_DIR=$1
+
+if [ -f "SHARED_DIR/configs/variables" ]; then
+	. "$SHARED_DIR"/configs/variables
+fi
+
+source "$SHARED_DIR"/scripts/custom_scripts/update_basic_solr_config.sh

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -12,6 +12,7 @@ for SCRIPT in ${SHARED_DIR}/scripts/custom_scripts/*.sh
 do
 	if [ -f "$SCRIPT" ]; then
 		echo "Running custom scripts"
+			# shellcheck source=/dev/null
 			source "$SCRIPT"
 	fi
 done

--- a/scripts/custom_scripts/update_basic_solr_config.sh
+++ b/scripts/custom_scripts/update_basic_solr_config.sh
@@ -3,7 +3,12 @@
 FGS_TARGET="/var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/"
 
 echo "Cloning basic-solr-config"
-git clone -b 4.x --single-branch https://github.com/utkdigitalinitiatives/basic-solr-config/ 4-x-utk
+if [ ! -d "$HOME_DIR"/4-x-utk ]; then
+	git clone -b 4.x --single-branch https://github.com/utkdigitalinitiatives/basic-solr-config/ 4-x-utk
+	chown -hR vagrant:vagrant 4-x-utk
+else
+	git -C "$HOME_DIR"/4-x-utk pull
+fi
 
 echo "Updating Fedora GSearch"
 # fix file paths in the new files
@@ -17,11 +22,11 @@ sudo cp 4-x-utk/foxmlToSolr.xslt $FGS_TARGET
 sudo cp -a 4-x-utk/islandora_transforms $FGS_TARGET
 
 # update file/directory ownership
-sudo chown -R tomcat7:tomcat7 $FGS_TARGET
+sudo chown -hR tomcat7:tomcat7 $FGS_TARGET
 
 echo "Updating Solr"
 # copy the appropriate Solr config files to Solr
 sudo cp 4-x-utk/solr-conf/* /usr/local/solr/collection1/conf/
 
 # update file/directory ownership
-sudo chown -R tomcat7:tomcat7 /usr/local/solr/collection1/conf
+sudo chown -hR tomcat7:tomcat7 /usr/local/solr/collection1/conf

--- a/scripts/custom_scripts/update_basic_solr_config.sh
+++ b/scripts/custom_scripts/update_basic_solr_config.sh
@@ -18,7 +18,7 @@ sudo cp -a 4-x-utk/islandora_transforms $FGS_TARGET
 sudo chown -R tomcat7:tomcat7 $FGS_TARGET
 
 echo "Updating Solr"
-
-sleep 2
-
-echo "Done"
+# copy the appropriate Solr config files to Solr
+sudo cp 4-x-utk/solr-conf/ /usr/local/solr/collection1/conf/
+# update file/directory ownership
+sudo chown -R tomcat7:tomcat7 /usr/local/solr/collection1/conf

--- a/scripts/custom_scripts/update_basic_solr_config.sh
+++ b/scripts/custom_scripts/update_basic_solr_config.sh
@@ -17,12 +17,12 @@ sed -i 's|/vhosts/fedora/tomcat|/var/lib/tomcat7|g' 4-x-utk/foxmlToSolr.xslt
 sed -i 's|/vhosts/fedora/tomcat|/var/lib/tomcat7|g' 4-x-utk/islandora_transforms/*.xslt
 
 # copy the appropriate fedoragsearch files to fedoragsearch
-sudo cp 4-x-utk/index.properties $FGS_TARGET
-sudo cp 4-x-utk/foxmlToSolr.xslt $FGS_TARGET
-sudo cp -a 4-x-utk/islandora_transforms $FGS_TARGET
+sudo cp 4-x-utk/index.properties "$FGS_TARGET"
+sudo cp 4-x-utk/foxmlToSolr.xslt "$FGS_TARGET"
+sudo cp -a 4-x-utk/islandora_transforms "$FGS_TARGET"
 
 # update file/directory ownership
-sudo chown -hR tomcat7:tomcat7 $FGS_TARGET
+sudo chown -hR tomcat7:tomcat7 "$FGS_TARGET"
 
 echo "Updating Solr"
 # copy the appropriate Solr config files to Solr

--- a/scripts/custom_scripts/update_basic_solr_config.sh
+++ b/scripts/custom_scripts/update_basic_solr_config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Updating Solr"
+
+sleep 2
+
+echo "Updating Fedora GSearch"
+
+sleep 2
+
+echo "Done"

--- a/scripts/custom_scripts/update_basic_solr_config.sh
+++ b/scripts/custom_scripts/update_basic_solr_config.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 
-echo "Updating Solr"
+FGS_TARGET="/var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/"
 
-sleep 2
+echo "Cloning basic-solr-config"
+git clone -b 4.x --single-branch https://github.com/utkdigitalinitiatives/basic-solr-config/ 4-x-utk
 
 echo "Updating Fedora GSearch"
+# fix file paths in the new files
+sed -i 's|/vhosts/fedora/solr|/usr/local/solr|g' 4-x-utk/index.properties
+sed -i 's|/vhosts/fedora/tomcat|/var/lib/tomcat7|g' 4-x-utk/foxmlToSolr.xslt
+sed -i 's|/vhosts/fedora/tomcat|/var/lib/tomcat7|g' 4-x-utk/islandora_transforms/*.xslt
+# copy the appropriate fedoragsearch files to fedoragsearch
+sudo cp 4-x-utk/index.properties $FGS_TARGET
+sudo cp 4-x-utk/foxmlToSolr.xslt $FGS_TARGET
+sudo cp -a 4-x-utk/islandora_transforms $FGS_TARGET
+# update file/directory ownership
+sudo chown -R tomcat7:tomcat7 $FGS_TARGET
+
+echo "Updating Solr"
 
 sleep 2
 

--- a/scripts/custom_scripts/update_basic_solr_config.sh
+++ b/scripts/custom_scripts/update_basic_solr_config.sh
@@ -10,15 +10,18 @@ echo "Updating Fedora GSearch"
 sed -i 's|/vhosts/fedora/solr|/usr/local/solr|g' 4-x-utk/index.properties
 sed -i 's|/vhosts/fedora/tomcat|/var/lib/tomcat7|g' 4-x-utk/foxmlToSolr.xslt
 sed -i 's|/vhosts/fedora/tomcat|/var/lib/tomcat7|g' 4-x-utk/islandora_transforms/*.xslt
+
 # copy the appropriate fedoragsearch files to fedoragsearch
 sudo cp 4-x-utk/index.properties $FGS_TARGET
 sudo cp 4-x-utk/foxmlToSolr.xslt $FGS_TARGET
 sudo cp -a 4-x-utk/islandora_transforms $FGS_TARGET
+
 # update file/directory ownership
 sudo chown -R tomcat7:tomcat7 $FGS_TARGET
 
 echo "Updating Solr"
 # copy the appropriate Solr config files to Solr
-sudo cp 4-x-utk/solr-conf/ /usr/local/solr/collection1/conf/
+sudo cp 4-x-utk/solr-conf/* /usr/local/solr/collection1/conf/
+
 # update file/directory ownership
 sudo chown -R tomcat7:tomcat7 /usr/local/solr/collection1/conf


### PR DESCRIPTION
# What does this PR do?

This PR adds two custom shell scripts to apply Vagrant-friendly changes to utkdigitalinitiatives/basic-solr-config's 4.x branch, making it easier to keep the Solr/Fedora GSearch part of the stack closer to what we're running on production.
# What's new?

 This PR adds the following:
- a `scripts/custom.sh` script
- a `scripts/custom_scripts/` directory
- a `scripts/custom_scripts/update_basic_solr_config.sh` script
# How should this be tested?

After cloning these changes: 
1. run `vagrant reload --provision`
2. the `update_basic_solr_config.sh` will print some notifications to STDOUT
3. `vagrant ssh` into the VM
4. `ls -l /usr/local/solr/collection1/conf/` and you should see timestamps reflecting the files updated by the shell scripts.
# Interested Parties

@cdeaneGit 
